### PR TITLE
Fix concurrent modification issue in SignalR future

### DIFF
--- a/signalr-client-sdk/src/main/java/microsoft/aspnet/signalr/client/SignalRFuture.java
+++ b/signalr-client-sdk/src/main/java/microsoft/aspnet/signalr/client/SignalRFuture.java
@@ -7,6 +7,7 @@ See License.txt in the project root for license information.
 package microsoft.aspnet.signalr.client;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -23,10 +24,10 @@ public class SignalRFuture<V> implements Future<V> {
     boolean mIsCancelled = false;
     boolean mIsDone = false;
     private V mResult = null;
-    private List<Runnable> mOnCancelled = new ArrayList<Runnable>();
-    private List<Action<V>> mOnDone = new ArrayList<Action<V>>();
+    private List<Runnable> mOnCancelled = Collections.synchronizedList(new ArrayList<Runnable>());
+    private List<Action<V>> mOnDone = Collections.synchronizedList(new ArrayList<Action<V>>());
     private Object mDoneLock = new Object();
-    private List<ErrorCallback> mErrorCallback = new ArrayList<ErrorCallback>();
+    private List<ErrorCallback> mErrorCallback = Collections.synchronizedList(new ArrayList<ErrorCallback>());
     private Queue<Throwable> mErrorQueue = new ConcurrentLinkedQueue<Throwable>();
     private Object mErrorLock = new Object();
     private Throwable mLastError = null;


### PR DESCRIPTION
I use `mHubConnection.disconnect()` method and sometimes my App crashes because of `ConcurrentModificationException`. I updated `ArrayLists` for callbacks for their synchronized versions and it looks like the issue is fixed.

```
Fatal Exception: java.util.ConcurrentModificationException
       at java.util.ArrayList$ArrayListIterator.next(ArrayList.java:573)
       at microsoft.aspnet.signalr.client.SignalRFuture.cancel(SignalRFuture.java:52)
       at microsoft.aspnet.signalr.client.UpdateableCancellableFuture.cancel(UpdateableCancellableFuture.java:39)
       at microsoft.aspnet.signalr.client.Connection.disconnect(Connection.java:538)
       at microsoft.aspnet.signalr.client.Connection.onError(Connection.java:779)
       at microsoft.aspnet.signalr.client.Connection$2.onError(Connection.java:331)
       at microsoft.aspnet.signalr.client.SignalRFuture.triggerError(SignalRFuture.java:185)
       at microsoft.aspnet.signalr.client.transport.AutomaticTransport$2.onError(AutomaticTransport.java:117)
       at microsoft.aspnet.signalr.client.SignalRFuture.onError(SignalRFuture.java:165)
       at microsoft.aspnet.signalr.client.transport.AutomaticTransport.resolveTransport(AutomaticTransport.java:122)
       at microsoft.aspnet.signalr.client.transport.AutomaticTransport.access$200(AutomaticTransport.java:24)
       at microsoft.aspnet.signalr.client.transport.AutomaticTransport$2.onError(AutomaticTransport.java:115)
       at microsoft.aspnet.signalr.client.SignalRFuture.triggerError(SignalRFuture.java:185)
       at microsoft.aspnet.signalr.client.http.java.NetworkRunnable.run(NetworkRunnable.java:92)
       at java.lang.Thread.run(Thread.java:818)
```